### PR TITLE
Replaced escaped underscores resulted by converting html text into string

### DIFF
--- a/internal/service/happy_birthday.go
+++ b/internal/service/happy_birthday.go
@@ -2,10 +2,12 @@ package service
 
 import (
 	"bartok/internal/datastruct"
+	"os"
+	"strings"
+	"time"
+
 	md "github.com/JohannesKaufmann/html-to-markdown"
 	"github.com/slack-go/slack"
-	"os"
-	"time"
 )
 
 type HappyBirthdayService interface {
@@ -24,6 +26,9 @@ func (w *happyBirthdayService) PostBirthDayCards() []datastruct.EmployeeEvent {
 	for _, event := range events {
 		if len(event.Text) > 0 {
 			markdown, _ := converter.ConvertString(event.Text)
+			if len(markdown) > 0 {
+				markdown = strings.ReplaceAll(markdown, `\_`, `_`)
+			}
 			err := w.slackService.SendMessage(channelId, []slack.Block{
 				textToTextWithMrkdwnBlock(markdown),
 			})


### PR DESCRIPTION
[This converter](https://github.com/JohannesKaufmann/html-to-markdown
) we're using is escaping some chars that are present in our emoji text. 
That's why, for some situations where emojis are added to the birthday calendar, the converter will fail to correctly parse their text and will escape some chars (in our case is the underscore that's present in some emojis)