### PR TITLE
Update Dockerfiles and DevContainer Configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,32 +1,31 @@
-ARG GO_VERSION=1.15
-ARG ALPINE_VERSION=3.13
+# syntax=docker/dockerfile:1
+ARG ALPINE_VERSION=3.20
+ARG ALPINE_SHA256=0a4eaa0eecf5f8c050e5bba433f58c052be7587ee8af3e8b3910ef9ab5fbe9f5
+FROM alpine:${ALPINE_VERSION}@sha256:${ALPINE_SHA256}
 
-FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION}
+RUN apk update &&  \
+    apk add --no-cache \
+    go \
+    bash \
+    build-base \
+    curl \
+    git \
+    sudo \
+    openssh-client \
+    zsh \
+    docker-cli
 
-RUN apk update && apk add bash
-RUN apk add build-base
-
-# Install packages and Go language server
-RUN apk add -q --update --progress --no-cache curl git sudo openssh-client zsh
-# RUN go get -u -v golang.org/x/tools/gopls 2>&1
-
-# Install oh-my-zsh
 RUN sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
 
-RUN go get -x -d github.com/stamblerre/gocode 2>&1 \
-    && go build -o gocode-gomod github.com/stamblerre/gocode \
-    && mv gocode-gomod $GOPATH/bin/ \
-    # # Install other tools.
-    && go get -u -v \
-        github.com/mdempsky/gocode \
-        github.com/uudashr/gopkgs/cmd/gopkgs \
-        github.com/ramya-rao-a/go-outline \
-        github.com/acroca/go-symbols \
-        github.com/go-delve/delve/cmd/dlv \
-        github.com/stamblerre/gocode \
-        github.com/rogpeppe/godef \
-        golang.org/x/lint/golint 2>&1
-
-RUN go get -u -v github.com/slack-go/slack
-
-CMD ["./main.go"]
+RUN <<EOF
+go install golang.org/x/tools/gopls@latest
+go install github.com/stamblerre/gocode@latest
+go install github.com/mdempsky/gocode@latest
+go install github.com/uudashr/gopkgs/v2/cmd/gopkgs@latest
+go install github.com/ramya-rao-a/go-outline@latest
+go install github.com/acroca/go-symbols@latest
+go install github.com/go-delve/delve/cmd/dlv@latest
+go install github.com/rogpeppe/godef@latest
+go install golang.org/x/lint/golint@latest
+go mod download github.com/slack-go/slack@latest
+EOF

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,19 @@
-
 {
     "dockerFile": "Dockerfile",
     "appPort": [
         "8000:8000"
     ],
-    "extensions": [
-        "ms-vscode.go"
-    ]
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "golang.Go"
+            ]
+        }
+    },
+    "mounts": [
+        "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
+    ],
+    "postCreateCommand": {
+        "configure-docker": "sudo chown $(whoami) /var/run/docker.sock"
+    }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,25 @@
-ARG GO_VERSION=1.20
-ARG ALPINE_VERSION=3.13
+# syntax=docker/dockerfile:1
+ARG GO_VERSION=1.23
+ARG ALPINE_VERSION=3.20
+ARG ALPINE_SHA256=d0b31558e6b3e4cc59f6011d79905835108c919143ebecc58f35965bf79948f4
+FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION}@sha256:${ALPINE_SHA256}
 
-FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION}
-
-RUN apk add --update git
+RUN apk update && \
+    apk add --no-cache \
+    git \
+    wget
 
 WORKDIR /app
 
-RUN go install github.com/cosmtrek/air@v1.27.10
-RUN go get -u -v github.com/slack-go/slack
-
 COPY go.mod go.sum .air.toml ./
 
+RUN go install github.com/cosmtrek/air@v1.27.10
+RUN go mod download github.com/slack-go/slack@latest
 RUN go mod download
 
 EXPOSE 8000
 
-HEALTHCHECK  --interval=5m --timeout=3s --start-period=2m\
-  CMD wget --no-verbose --tries=3 --spider http://localhost:8000/status/ || exit 1
+HEALTHCHECK  --interval=5m --timeout=3s --start-period=2m \
+    CMD wget --no-verbose --tries=3 --spider http://localhost:8000/status/ || exit 1
 
 CMD ["air"]


### PR DESCRIPTION
- Upgrade Alpine to 3.20 and Go to 1.23.
- Migrate from Go installation via golang image to direct apk installation.
- Update Dockerfile to use the latest Go and Alpine versions.
- Include Docker socket mount and adjust permissions with a postCreateCommand.